### PR TITLE
Cast column value to string. If is integer table is broken.

### DIFF
--- a/src/Mouf/Html/Widgets/StatsGrid/StatsColumn.php
+++ b/src/Mouf/Html/Widgets/StatsGrid/StatsColumn.php
@@ -79,7 +79,7 @@ class StatsColumn implements RecursiveIterator {
 			$values = $rowElem->getDistinctValues($dataset);
 			foreach ($values as $value) {
 				$statColumn = new StatsColumn();
-				$statColumn->value = $value;
+				$statColumn->value = (string) $value;
 				$statColumn->parent = $this;
 				$statColumn->columnDescriptor = $rowElem;
 				if (!empty($rows)) {


### PR DESCRIPTION
If columns or rows contains only integer, the table is broken.
I have cast value ($statColumn->value = (string) $value;) into Mouf/Html/Widgets/StatsGrid/StatsColumn.php to string line 82.
